### PR TITLE
Fix typings, MinimongoCollection needs generic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,10 +24,10 @@ export class MinimongoDb {
   getCollectionNames(): string[]
   localDb?: MinimongoDb
   remoteDb?: MinimongoDb 
-  collections: { [collectionName: string]: MinimongoCollection<any> }
+  collections: { [collectionName: string]: MinimongoCollection }
 }
 
-export interface MinimongoCollection<ItemType> {
+export interface MinimongoCollection<ItemType = any> {
   find(selector: any, options?: MinimongoCollectionFindOptions): { 
     fetch(success: (items: ItemType[]) => void, error: (err: any) => void): void
   }


### PR DESCRIPTION
If this module is used in typescripts strict mode, there is an error because in the utils.ts the `MinimongoCollection` has no generic type.

```bash
node_modules/minimongo/src/utils.d.ts:8:47 - error TS2314: Generic type 'MinimongoCollection<ItemType>' requires 1 type argument(s).

8 export function cloneLocalCollection(fromCol: MinimongoCollection, toCol: MinimongoCollection, success: () => void, error: (err: any) => void): void

node_modules/minimongo/src/utils.d.ts:8:75 - error TS2314: Generic type 'MinimongoCollection<ItemType>' requires 1 type argument(s).

8 export function cloneLocalCollection(fromCol: MinimongoCollection, toCol: MinimongoCollection, success: () => void, error: (err: any) => void): void

```

There are multiple ways to solve the problem.
I think because minimongo is a schema-less database, the generic `<ItemType>` should be optional for all Collections. This PR will set the default of `ItemType` to `any` so it must not always be provided.